### PR TITLE
Suggested additions for clusters/common packages

### DIFF
--- a/clusters/common/externals.cfg
+++ b/clusters/common/externals.cfg
@@ -1,2 +1,2 @@
-fixed       : bash cpio diffutils findutils gmake krb5 lustre m4 maven openssl pkg-config tar texinfo ghostscript
+fixed       : bash cpio diffutils findutils gmake krb5 lustre m4 maven openssl pkg-config tar ghostscript
 buildable   : doxygen gawk gcc groff libfuse openjdk openssh rsync texlive

--- a/clusters/common/packages.cfg
+++ b/clusters/common/packages.cfg
@@ -40,6 +40,7 @@ singleton:
     nasm
     googletest
     sqlite
+    texinfo
     perl
     bison
     byacc


### PR DESCRIPTION
**move autotools from fixed to built at the common level, so we can get newer versions.**

I noticed that the os-provided automake is at 1.15, and some of the spack specs will want 1.16.  Seems like a viable approach is to go ahead and install floating versions of `automake / autoconf / libtool` into to the common deployment, which is what this PR attempts to do.
